### PR TITLE
Artifacts part2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,9 +35,9 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          tags: ghcr.io/ksjh/silabs-firmware-builder:${{ env.sdk_version }}
-          cache-from: ghcr.io/ksjh/silabs-firmware-builder:cache-${{ env.sdk_version }}
-          cache-to: ghcr.io/ksjh/silabs-firmware-builder:cache-${{ env.sdk_version }}
+          tags: ghcr.io/${{ github.repository }}:${{ env.sdk_version }}
+          cache-from: ghcr.io/${{ github.repository }}:cache-${{ env.sdk_version }}
+          cache-to: ghcr.io/${{ github.repository }}:cache-${{ env.sdk_version }}
           push: true
           build-args:
             "GECKO_SDK_VERSION=v${{ env.sdk_version }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -163,6 +163,7 @@ jobs:
       device: ${{ matrix.device }}
       components: ${{ matrix.components }}
       patchpath: ${{ matrix.patchpath }}
+      sdkpatchpath: "RCPMultiPAN/GeckoSDK"
       sdk_version: 4.2.2
       metadata_fw_type: "rcp-uart-802154"
       metadata_extra: ${{ matrix.metadata_extra }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -237,3 +237,25 @@ jobs:
       metadata_fw_type: "ot-rcp"
       metadata_extra: ${{ matrix.metadata_extra }}
 
+  collect_artifacts:
+    name: download and publish all artifacts
+    runs-on: ubuntu-latest
+    needs: [ezsp-firmware-build, rcp-multi-pan-firmware-build, ot-rcp-firmware-build]
+    steps:
+      - uses: actions/checkout@v3.3.0
+      - uses: actions/download-artifact@v3
+        with:
+          path: firmware_builds
+      - name: Reorganise artifact structure
+        run: |
+          mv */*.gbl .
+          rm -rf */
+          ls
+        working-directory: firmware_builds
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update firmware builds
+          file_pattern: firmware_builds/*.gbl
+
+
+

--- a/.github/workflows/silabs-firmware-build.yaml
+++ b/.github/workflows/silabs-firmware-build.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: Generate gbl Firmware
         run: |
           cd ${{ inputs.firmware_name }}
-          commander gbl create build/release/${{ inputs.project_name }}.gbl \
+          commander gbl create build/release/${{ inputs.firmware_name }}.gbl \
                     --app build/release/${{ inputs.project_name }}.out \
                     --device ${{ inputs.device }} --metadata version.json
 
@@ -111,4 +111,4 @@ jobs:
         if: success() || failure()
         with:
           name: ${{ inputs.firmware_name }}
-          path: ${{ inputs.firmware_name }}
+          path: ${{ inputs.firmware_name }}/build/release/${{ inputs.firmware_name }}.gbl

--- a/.github/workflows/silabs-firmware-build.yaml
+++ b/.github/workflows/silabs-firmware-build.yaml
@@ -46,7 +46,7 @@ jobs:
     name: Build firmware
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ksjh/silabs-firmware-builder:${{ inputs.sdk_version }}
+      image: ghcr.io/${{ github.repository }}:${{ inputs.sdk_version }}
       options: --user root
     defaults:
       run:

--- a/OpenThreadRCP/GeckoSDK/0003-openthread-reproducible-build.patch
+++ b/OpenThreadRCP/GeckoSDK/0003-openthread-reproducible-build.patch
@@ -1,0 +1,26 @@
+From a59b653261323d0bd1a1320ec529d7ea1908b077 Mon Sep 17 00:00:00 2001
+From: Tim Lunn <tim@feathertop.org>
+Date: Fri, 7 Apr 2023 21:27:54 +1000
+Subject: [PATCH] openthread reproducible build
+
+---
+ util/third_party/openthread/src/core/api/instance_api.cpp | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/util/third_party/openthread/src/core/api/instance_api.cpp b/util/third_party/openthread/src/core/api/instance_api.cpp
+index 9cc35c96c..c5abf0774 100644
+--- a/util/third_party/openthread/src/core/api/instance_api.cpp
++++ b/util/third_party/openthread/src/core/api/instance_api.cpp
+@@ -49,9 +49,6 @@
+ #include <cutils/properties.h>
+ #endif
+ #else // __ANDROID__
+-#if defined(__DATE__)
+-#define OPENTHREAD_BUILD_DATETIME __DATE__ " " __TIME__
+-#endif
+ #endif // __ANDROID__
+ #endif // !defined(OPENTHREAD_BUILD_DATETIME)
+ 
+-- 
+2.37.2
+

--- a/RCPMultiPAN/GeckoSDK/0003-openthread-reproducible-build.patch
+++ b/RCPMultiPAN/GeckoSDK/0003-openthread-reproducible-build.patch
@@ -1,0 +1,26 @@
+From a59b653261323d0bd1a1320ec529d7ea1908b077 Mon Sep 17 00:00:00 2001
+From: Tim Lunn <tim@feathertop.org>
+Date: Fri, 7 Apr 2023 21:27:54 +1000
+Subject: [PATCH] openthread reproducible build
+
+---
+ util/third_party/openthread/src/core/api/instance_api.cpp | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/util/third_party/openthread/src/core/api/instance_api.cpp b/util/third_party/openthread/src/core/api/instance_api.cpp
+index 9cc35c96c..c5abf0774 100644
+--- a/util/third_party/openthread/src/core/api/instance_api.cpp
++++ b/util/third_party/openthread/src/core/api/instance_api.cpp
+@@ -49,9 +49,6 @@
+ #include <cutils/properties.h>
+ #endif
+ #else // __ANDROID__
+-#if defined(__DATE__)
+-#define OPENTHREAD_BUILD_DATETIME __DATE__ " " __TIME__
+-#endif
+ #endif // __ANDROID__
+ #endif // !defined(OPENTHREAD_BUILD_DATETIME)
+ 
+-- 
+2.37.2
+


### PR DESCRIPTION
This continues on from the previous PR #13 

I've taken a middle ground here, stopping short of doing proper 'releases'. This collects up all the firmware binaries and commits them to a sub-folder on the repository. This should be much more intuitive for users to grab the gbl files. Also will be able to link to the binaries from SL Web Tools.

There is no versioning or filtering on tags, although both would be possible to add in the future. I've patched Gecko SDK to ensure the builds are reproducible, so the firmware binaries wont be updated unless there are actual changes affecting them.